### PR TITLE
Fix CIEV URC signal bar level compile warning

### DIFF
--- a/source/cellular_r4_urc_handler.c
+++ b/source/cellular_r4_urc_handler.c
@@ -164,7 +164,7 @@ static CellularPktStatus_t _parseUrcIndicationCsq( CellularContext_t * pContext,
     CellularATError_t atCoreStatus = CELLULAR_AT_SUCCESS;
     CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
     int32_t retStrtoi = 0;
-    int16_t csqBarLevel = CELLULAR_INVALID_SIGNAL_BAR_VALUE;
+    uint8_t csqBarLevel = CELLULAR_INVALID_SIGNAL_BAR_VALUE;
     CellularSignalInfo_t signalInfo = { 0 };
 
     if( ( pContext == NULL ) || ( pUrcStr == NULL ) )
@@ -179,7 +179,8 @@ static CellularPktStatus_t _parseUrcIndicationCsq( CellularContext_t * pContext,
 
     if( atCoreStatus == CELLULAR_AT_SUCCESS )
     {
-        if( ( retStrtoi >= INT16_MIN ) && ( retStrtoi <= ( int32_t ) INT16_MAX ) )
+        /* Possible value is 0 to 5. */
+        if( ( retStrtoi >= 0 ) && ( retStrtoi <= 5 ) )
         {
             csqBarLevel = retStrtoi;
         }

--- a/source/cellular_r4_urc_handler.c
+++ b/source/cellular_r4_urc_handler.c
@@ -179,7 +179,14 @@ static CellularPktStatus_t _parseUrcIndicationCsq( CellularContext_t * pContext,
 
     if( atCoreStatus == CELLULAR_AT_SUCCESS )
     {
-        /* Possible value is 0 to 5. */
+        /* Possible value is 0 to 5.
+         *  o 0: < -105 dBm
+         *  o 1 : < -93 dBm
+         *  o 2 : < -81 dBm
+         *  o 3 : < -69 dBm
+         *  o 4 : < -57 dBm
+         *  o 5 : >= -57 dBm
+         */
         if( ( retStrtoi >= 0 ) && ( retStrtoi <= 5 ) )
         {
             csqBarLevel = retStrtoi;
@@ -260,22 +267,15 @@ static void _cellular_UrcProcessCiev( CellularContext_t * pContext,
                     {
                         case CIEV_POS_SIGNAL:
                             LogDebug( ( "_cellular_UrcProcessCiev: CIEV_POS_SIGNAL" ) );
-                            /* This URC only gives bar level and not the exact RSSI value. */
 
-                            /*
-                             *  o 0: < -105 dBm
-                             *  o 1 : < -93 dBm
-                             *  o 2 : < -81 dBm
-                             *  o 3 : < -69 dBm
-                             *  o 4 : < -57 dBm
-                             *  o 5 : >= -57 dBm
-                             */
-                            /* Parse the signal Bar level from string. */
+                            /* Parse the signal Bar level from string. This URC only
+                             * gives bar level and not the exact RSSI value. */
                             pktStatus = _parseUrcIndicationCsq( pContext, pUrcStr );
                             break;
 
                         case CIEV_POS_CALL:
                             LogDebug( ( "_cellular_UrcProcessCiev: CIEV_POS_CALL" ) );
+
                             /* Parse PS ACT/DEACT from +CIEV URC indication. */
                             /* This URC does not tell which context ID number is ACT/DEACT. */
                             pktStatus = _parseUrcIndicationCall( ( const CellularContext_t * ) pContext, pUrcStr );


### PR DESCRIPTION


<!--- Title -->

Description
-----------
* Use type uint8_t for possible value 0 to 5

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
